### PR TITLE
Add Admin, Emergency, and Appointment entities with related layers

### DIFF
--- a/src/main/java/sliit/pg09/carcare/admin/Admin.java
+++ b/src/main/java/sliit/pg09/carcare/admin/Admin.java
@@ -1,0 +1,14 @@
+package sliit.pg09.carcare.admin;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Entity
+public class Admin {
+    @Id
+    private String username;
+}

--- a/src/main/java/sliit/pg09/carcare/admin/AdminController.java
+++ b/src/main/java/sliit/pg09/carcare/admin/AdminController.java
@@ -1,0 +1,10 @@
+package sliit.pg09.carcare.admin;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class AdminController {
+    @Autowired
+    AdminService adminService;
+}

--- a/src/main/java/sliit/pg09/carcare/admin/AdminRepository.java
+++ b/src/main/java/sliit/pg09/carcare/admin/AdminRepository.java
@@ -1,0 +1,8 @@
+package sliit.pg09.carcare.admin;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AdminRepository extends JpaRepository<Admin, String> {
+}

--- a/src/main/java/sliit/pg09/carcare/admin/AdminService.java
+++ b/src/main/java/sliit/pg09/carcare/admin/AdminService.java
@@ -1,0 +1,12 @@
+package sliit.pg09.carcare.admin;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class AdminService {
+    private final AdminRepository adminRepository;
+
+    public AdminService(AdminRepository adminRepository) {
+        this.adminRepository = adminRepository;
+    }
+}

--- a/src/main/java/sliit/pg09/carcare/common/configs/Security.java
+++ b/src/main/java/sliit/pg09/carcare/common/configs/Security.java
@@ -61,7 +61,7 @@ public class Security {
                     user.get("email").toString(),
                     user.get("picture").toString()
             )));
-            response.sendRedirect("/client/dashboard");
+            response.sendRedirect("/client");
         }
     }
 }

--- a/src/main/java/sliit/pg09/carcare/emergency/Emergency.java
+++ b/src/main/java/sliit/pg09/carcare/emergency/Emergency.java
@@ -1,0 +1,42 @@
+package sliit.pg09.carcare.emergency;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import sliit.pg09.carcare.vehicle.Vehicle;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@Entity
+public class Emergency {
+    @EmbeddedId
+    private EmergencyId id;
+
+    private String description;
+    private String location;
+
+    @MapsId("vehicleLicense")
+    @ManyToOne
+    @JoinColumn(name = "vehicle")
+    private Vehicle vehicle;
+
+    public Emergency(Vehicle vehicle, LocalDateTime time) {
+        this.id = new EmergencyId();
+        this.vehicle = vehicle;
+        this.id.setVehicleLicense(vehicle.getLicense());
+        this.id.setEmergencyTime(time);
+    }
+
+    @Embeddable
+    @Data
+    @NoArgsConstructor
+    public static class EmergencyId implements java.io.Serializable {
+        @Column(name = "vehicle")
+        private String vehicleLicense;
+
+        @Column(name = "time")
+        private LocalDateTime emergencyTime;
+    }
+}

--- a/src/main/java/sliit/pg09/carcare/emergency/EmergencyController.java
+++ b/src/main/java/sliit/pg09/carcare/emergency/EmergencyController.java
@@ -1,0 +1,10 @@
+package sliit.pg09.carcare.emergency;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class EmergencyController {
+    @Autowired
+    EmergencyService emergencyService;
+}

--- a/src/main/java/sliit/pg09/carcare/emergency/EmergencyRepository.java
+++ b/src/main/java/sliit/pg09/carcare/emergency/EmergencyRepository.java
@@ -1,0 +1,8 @@
+package sliit.pg09.carcare.emergency;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EmergencyRepository extends JpaRepository<Emergency, Emergency.EmergencyId> {
+}

--- a/src/main/java/sliit/pg09/carcare/emergency/EmergencyService.java
+++ b/src/main/java/sliit/pg09/carcare/emergency/EmergencyService.java
@@ -1,0 +1,12 @@
+package sliit.pg09.carcare.emergency;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmergencyService {
+    private final EmergencyRepository emergencyRepository;
+
+    public EmergencyService(EmergencyRepository emergencyRepository) {
+        this.emergencyRepository = emergencyRepository;
+    }
+}

--- a/src/main/java/sliit/pg09/carcare/ongoingAppointment/OngoingAppointment.java
+++ b/src/main/java/sliit/pg09/carcare/ongoingAppointment/OngoingAppointment.java
@@ -1,0 +1,40 @@
+package sliit.pg09.carcare.ongoingAppointment;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import sliit.pg09.carcare.vehicle.Vehicle;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@Entity
+public class OngoingAppointment {
+    @EmbeddedId
+    private OngoingAppointmentId id;
+
+    @ManyToOne
+    @MapsId("license")
+    @JoinColumn(name = "vehicle_license")
+    private Vehicle vehicle;
+
+    // Convenience method to set both vehicle and appointment time
+    public void setAppointmentDetails(Vehicle vehicle, LocalDateTime appointmentTime) {
+        if (this.id == null) {
+            this.id = new OngoingAppointmentId();
+        }
+        this.vehicle = vehicle;
+        this.id.setLicense(vehicle.getLicense());
+        this.id.setAppointmentTime(appointmentTime);
+    }
+
+    @Embeddable
+    @Data
+    @NoArgsConstructor
+    public static class OngoingAppointmentId implements Serializable {
+        private String license;  // Matches Vehicle's @Id field name
+        private LocalDateTime appointmentTime;
+    }
+}

--- a/src/main/java/sliit/pg09/carcare/ongoingAppointment/OngoingAppointmentController.java
+++ b/src/main/java/sliit/pg09/carcare/ongoingAppointment/OngoingAppointmentController.java
@@ -1,0 +1,10 @@
+package sliit.pg09.carcare.ongoingAppointment;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class OngoingAppointmentController {
+    @Autowired
+    OngoingAppointmentService ongoingAppointmentService;
+}

--- a/src/main/java/sliit/pg09/carcare/ongoingAppointment/OngoingAppointmentRepository.java
+++ b/src/main/java/sliit/pg09/carcare/ongoingAppointment/OngoingAppointmentRepository.java
@@ -1,0 +1,8 @@
+package sliit.pg09.carcare.ongoingAppointment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OngoingAppointmentRepository extends JpaRepository<OngoingAppointment, OngoingAppointment.OngoingAppointmentId> {
+}

--- a/src/main/java/sliit/pg09/carcare/ongoingAppointment/OngoingAppointmentService.java
+++ b/src/main/java/sliit/pg09/carcare/ongoingAppointment/OngoingAppointmentService.java
@@ -1,0 +1,12 @@
+package sliit.pg09.carcare.ongoingAppointment;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class OngoingAppointmentService {
+    private final OngoingAppointmentRepository ongoingAppointmentRepository;
+
+    public OngoingAppointmentService(OngoingAppointmentRepository ongoingAppointmentRepository) {
+        this.ongoingAppointmentRepository = ongoingAppointmentRepository;
+    }
+}

--- a/src/main/java/sliit/pg09/carcare/pendingAppointment/PendingAppointment.java
+++ b/src/main/java/sliit/pg09/carcare/pendingAppointment/PendingAppointment.java
@@ -1,0 +1,44 @@
+package sliit.pg09.carcare.pendingAppointment;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import sliit.pg09.carcare.vehicle.Vehicle;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@Entity
+public class PendingAppointment {
+    @EmbeddedId
+    private PendingAppointmentId id;
+
+    @ManyToOne
+    @MapsId("license")  // Maps to the field name in PendingAppointmentId
+    @JoinColumn(name = "vehicle_license")
+    private Vehicle vehicle;
+
+    private String description;
+    private LocalDateTime scheduledTime;
+    private String status;
+
+    // Convenience method to set both vehicle and created time
+    public void setAppointmentDetails(Vehicle vehicle, LocalDateTime createdTime) {
+        if (this.id == null) {
+            this.id = new PendingAppointmentId();
+        }
+        this.vehicle = vehicle;
+        this.id.setLicense(vehicle.getLicense());
+        this.id.setCreatedTime(createdTime);
+    }
+
+    @Embeddable
+    @Data
+    @NoArgsConstructor
+    public static class PendingAppointmentId implements Serializable {
+        private String license;  // Matches with Vehicle's @Id field name
+        private LocalDateTime createdTime;
+    }
+}

--- a/src/main/java/sliit/pg09/carcare/pendingAppointment/PendingAppointmentController.java
+++ b/src/main/java/sliit/pg09/carcare/pendingAppointment/PendingAppointmentController.java
@@ -1,0 +1,10 @@
+package sliit.pg09.carcare.pendingAppointment;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class PendingAppointmentController {
+    @Autowired
+    PendingAppointmentService pendingAppointmentService;
+}

--- a/src/main/java/sliit/pg09/carcare/pendingAppointment/PendingAppointmentRepository.java
+++ b/src/main/java/sliit/pg09/carcare/pendingAppointment/PendingAppointmentRepository.java
@@ -1,0 +1,8 @@
+package sliit.pg09.carcare.pendingAppointment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PendingAppointmentRepository extends JpaRepository<PendingAppointment, PendingAppointment.PendingAppointmentId> {
+}

--- a/src/main/java/sliit/pg09/carcare/pendingAppointment/PendingAppointmentService.java
+++ b/src/main/java/sliit/pg09/carcare/pendingAppointment/PendingAppointmentService.java
@@ -1,0 +1,12 @@
+package sliit.pg09.carcare.pendingAppointment;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class PendingAppointmentService {
+    private final PendingAppointmentRepository pendingAppointmentRepository;
+
+    public PendingAppointmentService(PendingAppointmentRepository pendingAppointmentRepository) {
+        this.pendingAppointmentRepository = pendingAppointmentRepository;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 #spring.sql.init.mode=always
 #Thymleaf Options


### PR DESCRIPTION
### Description

This pull request introduces new entities: Admin, Emergency, OngoingAppointment, and PendingAppointment. Along with the entities, their respective controllers, services, and repositories have been added. Additionally, the application properties have been updated to configure Hibernate's `ddl-auto` setting to `create`. Security configuration was modified to redirect clients to the root instead of the dashboard.

### Checklist

- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes